### PR TITLE
Локальные переменные emacs auctex должны быть в конце документа.

### DIFF
--- a/bsuir-std.cls
+++ b/bsuir-std.cls
@@ -1,9 +1,3 @@
-%%% Local Variables:
-%%% coding: utf-8
-%%% mode: latex
-%%% TeX-engine: xetex
-%%% End:
-
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{xelatex-bsuir-std/bsuir-std}[2024/12/16 Class conforming to BSUIR standard]
 
@@ -331,3 +325,9 @@
   \SearchList{dash}{\textendash}{--}
 
 \fi
+
+%%% Local Variables:
+%%% coding: utf-8
+%%% mode: latex
+%%% TeX-engine: xetex
+%%% End:


### PR DESCRIPTION
Eсли они вообще имеют смысл в теховском классе, потому что их удобство в том, что можно указать основной документ с которого начинать компиляцию. Через них так же можно сказать емаксу использовать Biber
(В нём это прям нажатием кнопок делается). Можете удалять.

По вашему латех классу видно, что вы очень много скопировали из моего.
Копируйте ещё:
https://github.com/artsi0m/SST/blob/master/bachelor-thesis/bsuir-std.cls
Только учтите, что скоро надо будет переходить на luatex всё равно.

Я завтра как раз иду сдавать записку нормоконтролю на подпись и куратору специальности.
Очень волнуюсь по этому поводу, у меня много чего не написано и я не хотел бы отчисляться, хотя мне уже найсточиво предлагали.  Поэтому я не смогу прямо сейчас сам как-то сильно контрибьютить, хоть и хотелось бы:
мне надо писать сами главы диплома. 

Сейчас как-то сильно контрибьютить не смогу, но вот этим пул реквестом дам знать, что у меня тоже есть хелатех класс.

Когда меня отчислят или я защищу диплом, то у меня будет больше свободного времени и я закину ещё несколько кусков кода, которые требуют на нормоконтроле и по СТП.

Если что, то вот мои контакты:
https://t.me/artsi0m
https://t.me/artsi0_0m